### PR TITLE
feat: semantic-release on merge to main, update actions to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
@@ -13,8 +11,8 @@ jobs:
       matrix:
         node-version: [20, 22, 24]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,49 +1,45 @@
-name: Release & Publish
+name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
 
 permissions:
   contents: write
+  issues: write
+  pull-requests: write
   id-token: write
 
 jobs:
-  publish:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+  release:
+    needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.target_commitish }}
-
-      - uses: actions/setup-node@v4
+          persist-credentials: false
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
-          registry-url: https://registry.npmjs.org
-
-      - name: Validate semver tag
-        id: version
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          # Strip leading 'v' if present
-          VERSION="${TAG#v}"
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'; then
-            echo "::error::Tag '$TAG' is not a valid semver version"
-            exit 1
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
       - run: npm ci
-
-      - run: npm test
-
       - run: npm run build
-
-      - name: Set package version from tag
-        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
-
-      - name: Publish to npm
-        run: npm publish --provenance --access public
+      - uses: cycjimmy/semantic-release-action@v6
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,14 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": true
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Summary

- **Fix deprecation warnings**: Update `actions/checkout` and `actions/setup-node` from **v4 to v6** (Node 22 runners, no more deprecation warnings)
- **Automate releases on merge to main**: Replace the manual `on: release` trigger with [`semantic-release`](https://github.com/semantic-release/semantic-release) via [`cycjimmy/semantic-release-action@v6`](https://github.com/cycjimmy/semantic-release-action)
- **Add `.releaserc.json`** with standard plugin chain: commit-analyzer → release-notes-generator → npm → github

### How it works after merge

1. Push/merge to `main` triggers the **Release** workflow
2. Tests run on Node 20, 22, 24 — if any fail, release is skipped
3. `semantic-release` analyzes commit messages since the last tag:
   - `fix:` → patch bump (1.1.0 → 1.1.1)
   - `feat:` → minor bump (1.1.0 → 1.2.0)
   - `BREAKING CHANGE:` in footer or `feat!:` → major bump (1.1.0 → 2.0.0)
4. If a release is warranted, it automatically:
   - Updates `package.json` version
   - Creates a git tag (`v1.2.0`)
   - Creates a GitHub Release with generated notes
   - Publishes to npm

If no release-worthy commits exist (e.g. `ci:`, `docs:`, `chore:`), nothing is published.

### Workflow changes

| Workflow | Trigger | What it does |
|---|---|---|
| **CI** (`ci.yml`) | PRs to main | Test on Node 20/22/24 (gate for merge) |
| **Release** (`release.yml`) | Push to main | Test on Node 20/22/24 → `semantic-release` (version, tag, GitHub Release, npm publish) |

### Action version updates

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 (Node 20, deprecated) | **v6** (Node 22) |
| `actions/setup-node` | v4 (Node 20, deprecated) | **v6** (Node 22) |

### Setup required

- **`NPM_TOKEN`** repository secret must be configured (Settings → Secrets → Actions)
- After merge, the first `feat:` or `fix:` commit will trigger the initial release. To anchor semantic-release to the current version, create a `v1.1.0` tag on main before merging: `git tag v1.1.0 && git push origin v1.1.0`

## Test plan

- [x] YAML validates correctly
- [x] Build and all 10 tests pass locally
- [ ] CI workflow runs on this PR with no deprecation warnings
- [ ] After merge, Release workflow triggers and semantic-release runs

https://claude.ai/code/session_01XyrxhA5TiwpxNy6XtFFQSc